### PR TITLE
enable wayland in gdm

### DIFF
--- a/archlive/airootfs/etc/gdm/custom.conf
+++ b/archlive/airootfs/etc/gdm/custom.conf
@@ -1,5 +1,4 @@
-# Enable automatic login for user
 [daemon]
 AutomaticLogin=root
 AutomaticLoginEnable=True
-WaylandEnable=false
+WaylandEnable=true


### PR DESCRIPTION
since after changing priority from `intel then amd` to `amd then intel` fixed the startup manager error in amd, but on the way we broke intel as well, we might need to make one for amd, one for intel, but @piotr25691 was testing, gnome didn't load, and stuck on black screen, turns out its best to use wayland in amd, i have amd hardware running ubuntu 23.04 and i had the same issues when running gnome in X (not twitter) or X11. enabling wayland might fix the issue