### PR TITLE
grub shift patch

### DIFF
--- a/archiso/airootfs/usr/local/bin/patch-grub
+++ b/archiso/airootfs/usr/local/bin/patch-grub
@@ -1,27 +1,33 @@
-#!/bin/sh
+#!/bin/bash
 
 # Get the root directory
 ROOT=$1
-
+OSPROBER="$(os-prober)"
+if [[ "$OSPROBER" ]]; then
+  SHIFT=3
+else
+  SHIFT=0
+fi
+  
 # Take a backup and change to a temporary directory
 cp $ROOT/boot/grub/grub.cfg $ROOT/boot/grub/grub.cfg.bak
 cd /tmp
 
 # Remove advanced options
-sed -i "109,127d" $ROOT/boot/grub/grub.cfg
+sed -i "$((109+$SHIFT)),$((127+$SHIFT))d" $ROOT/boot/grub/grub.cfg
 
 # Save boot option syntax
-sed -n "92,108p" $ROOT/boot/grub/grub.cfg > boot.option
+sed -n "$((92+$SHIFT)),$((108+SHIFT))p" $ROOT/boot/grub/grub.cfg > boot.option
 
 # Copy the boot options
-sed -i "109r boot.option" $ROOT/boot/grub/grub.cfg
-sed -i "127r boot.option" $ROOT/boot/grub/grub.cfg
+sed -i "$((109+$SHIFT))r boot.option" $ROOT/boot/grub/grub.cfg
+sed -i "$((127+$SHIFT))r boot.option" $ROOT/boot/grub/grub.cfg
 
 # Rename the boot options
-sed -i "92s/aerOS Linux/aerOS/g" $ROOT/boot/grub/grub.cfg
-sed -i "110s/aerOS Linux/aerOS with safe graphics driver/g" $ROOT/boot/grub/grub.cfg
-sed -i "128s/aerOS Linux/aerOS in TTY mode/g" $ROOT/boot/grub/grub.cfg
+sed -i "$((92+$SHIFT))s/aerOS Linux/aerOS/g" $ROOT/boot/grub/grub.cfg
+sed -i "$((110+SHIFT))s/aerOS Linux/aerOS with safe graphics driver/g" $ROOT/boot/grub/grub.cfg
+sed -i "$((SHIFT+128))s/aerOS Linux/aerOS in TTY mode/g" $ROOT/boot/grub/grub.cfg
 
 # Change kernel parameters for newly created boot options
-sed -i "123s/quiet splash/quiet splash nomodeset/g" $ROOT/boot/grub/grub.cfg
-sed -i "141s/quiet splash loglevel=3/loglevel=3 \$vt_handoff 3/g" $ROOT/boot/grub/grub.cfg
+sed -i "$((SHIFT+123))s/quiet splash/quiet splash nomodeset/g" $ROOT/boot/grub/grub.cfg
+sed -i "$((SHIFT+141))s/quiet splash loglevel=3/loglevel=3 \$vt_handoff 3/g" $ROOT/boot/grub/grub.cfg

--- a/archiso/airootfs/usr/local/bin/patch-grub
+++ b/archiso/airootfs/usr/local/bin/patch-grub
@@ -2,6 +2,8 @@
 
 # Get the root directory
 ROOT=$1
+
+# Detemine shift-lines amount
 OSPROBER="$(os-prober)"
 if [[ "$OSPROBER" ]]; then
   SHIFT=3
@@ -31,3 +33,13 @@ sed -i "$((SHIFT+128))s/aerOS Linux/aerOS in TTY mode/g" $ROOT/boot/grub/grub.cf
 # Change kernel parameters for newly created boot options
 sed -i "$((SHIFT+123))s/quiet splash/quiet splash nomodeset/g" $ROOT/boot/grub/grub.cfg
 sed -i "$((SHIFT+141))s/quiet splash loglevel=3/loglevel=3 \$vt_handoff 3/g" $ROOT/boot/grub/grub.cfg
+
+# Check for syntax errors and revert if found
+if grub-script-check /boot/grub/grub.cfg; then
+  echo "GRUB patched successfully."
+  exit 0
+else
+  echo "Failed in patching GRUB."
+  cp $ROOT/boot/grub/grub.cfg.bak $ROOT/boot/grub/grub.cfg
+  exit 1
+fi


### PR DESCRIPTION
this will add a shift variable used for when lines change before the predefined line numbers specified in the code

example:
SHIFT=0 when you only boot aerOS
SHIFT=3 when you boot aerOS with Windows 10/11